### PR TITLE
Double quote to dedouble double quotes

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -175,7 +175,7 @@ if (minYear) {
             let value = object[key]
             if (value == null) {
                 value = ''
-            } else if (typeof(value) == 'string' && value.indexOf(csvSeparator) != -1) {
+            } else if (typeof(value) == 'string') {
                 value.replace('"', '""')
                 value = '"' + value + '"'
             }


### PR DESCRIPTION
Šobrīd beigu cesvā sanāk dubļas dubļukvuotes, piemēram, `Sabiedrība ar ierobežotu atbildību ""Tet""`. Principā viņas vispār nedrīkstētu iekšā nekvuotētā vērtībā būt, bet, ja ir, tad excelis laikam uztver burtiski un attēlo abas. Ja vērtība būtu kvuotēta `"Sabiedrība ar ierobežotu atbildību ""Tet"""`, tad interpretē korekti.

No kurienes tā dubultācija? No sākuma datiem? Tad laikam varētu risināt arī `smartSplit`'ā deduplicējot eskapētās kvuotes? Bet īsti neizsekoju viņa loģikai.

Tā vietā pamēģināju enablēt to kvuotēšanu un eskapēšanu visiem stringiem (un kvuotēt tak drīkst visus laukus) un nez kāpēc viss kļuva ok ;D